### PR TITLE
Updated table styling to work for dark and light

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ The packages are paginated, by default a page has a maximum of 10 packages. This
 </x-dashboard>
 ```
 
+## Customizing the view
+
+If you want to customize the view used to render this tile, run this command:
+
+```bash
+php artisan vendor:publish --provider="TJVB\PackagistTile\PackagistTileServiceProvider" --tag="dashboard-packagist-views"
+```
+
 ## Testing
 
 ``` bash

--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -1,27 +1,26 @@
 <x-dashboard-tile :position="$position">
     <div class="grid grid-rows-auto-1 gap-2 h-full">
-        <div class="flex items-center justify-center rounded-full"
-            style="background-color: rgba(255, 255, 255, .9)" >
-            <div class="">
-                @lang('dashboard-packagist-tile::packagisttile.Packagist data')
-            </div>
+        <div class="flex items-center justify-center">
+            @lang('dashboard-packagist-tile::packagisttile.Packagist data')
         </div>
         <div wire:poll.{{ $refreshIntervalInSeconds }}s class="self-center | divide-y-2">
-            <table class="table-auto w-full">
-                <tr class="bg-gray-600" >
+            <table class="w-full">
+                <thead class="bg-dimmed text-invers">
+                <tr>
                     <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Package')</th>
                     <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Daily')</th>
                     <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Monthly')</th>
                     <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Total')</th>
                     @if(config('dashboard.tiles.packagist.display.faves'))
-                    <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Faves')</th>
+                        <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.Faves')</th>
                     @endif
                     @if(config('dashboard.tiles.packagist.display.github_stars'))
                         <th class="border p-2">@lang('dashboard-packagist-tile::packagisttile.GitHub stars')</th>
                     @endif
                 </tr>
+                </thead>
                 @if(isset($totals))
-                    <tr class="bg-gray-400" >
+                    <tr class="border-b bg-invers text-dimmed">
                         <td class="border p-2">
                             @lang('dashboard-packagist-tile::packagisttile.Totals')
                         </td>
@@ -35,9 +34,9 @@
                             {{number_format($totals['totalDownloads'], 0, ',', '.')}}
                         </td>
                         @if(config('dashboard.tiles.packagist.display.faves'))
-                        <td class="border p-2">
-                            {{number_format($totals['favers'], 0, ',', '.')}}
-                        </td>
+                            <td class="border p-2">
+                                {{number_format($totals['favers'], 0, ',', '.')}}
+                            </td>
                         @endif
                         @if(config('dashboard.tiles.packagist.display.github_stars'))
                             <td class="border p-2">
@@ -47,7 +46,7 @@
                     </tr>
                 @endif
                 @foreach($packages as $package)
-                    <tr class="@if($loop->even) bg-gray-200 @endif @if($package->getAbandoned())line-through @endif">
+                    <tr class="@if($loop->even) bg-dimmed text-invers @endif @if($package->getAbandoned())line-through @endif">
                         <td class="border p-2">
                             <a href="https://packagist.org/packages/{{$package->getname()}}" target="_blank">{{$package->getname()}}</a>
                         </td>
@@ -61,9 +60,9 @@
                             {{number_format($package->getTotalDownloads(), 0, ',', '.')}}
                         </td>
                         @if(config('dashboard.tiles.packagist.display.faves'))
-                        <td class="border p-2">
-                            {{number_format($package->getFavers(), 0, ',', '.')}}
-                        </td>
+                            <td class="border p-2">
+                                {{number_format($package->getFavers(), 0, ',', '.')}}
+                            </td>
                         @endif
                         @if(config('dashboard.tiles.packagist.display.github_stars'))
                             <td class="border p-2">
@@ -73,7 +72,7 @@
                     </tr>
                 @endforeach
                 @if(isset($totals))
-                    <tr class="bg-gray-400" >
+                    <tr class="border-b bg-invers text-dimmed">
                         <td class="border p-2">
                             @lang('dashboard-packagist-tile::packagisttile.Totals')
                         </td>
@@ -87,9 +86,9 @@
                             {{number_format($totals['totalDownloads'], 0, ',', '.')}}
                         </td>
                         @if(config('dashboard.tiles.packagist.display.faves'))
-                        <td class="border p-2">
-                            {{number_format($totals['favers'], 0, ',', '.')}}
-                        </td>
+                            <td class="border p-2">
+                                {{number_format($totals['favers'], 0, ',', '.')}}
+                            </td>
                         @endif
                         @if(config('dashboard.tiles.packagist.display.github_stars'))
                             <td class="border p-2">


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/9788214/161623946-d14d4175-f739-4181-abe8-6697620c3fd8.png)
![image](https://user-images.githubusercontent.com/9788214/161623896-d2502462-2165-461f-abc1-a19e1cbe205a.png)

# After
![image](https://user-images.githubusercontent.com/9788214/161623785-5530531a-c758-4837-b6f5-2b5f17386eed.png)
![image](https://user-images.githubusercontent.com/9788214/161623817-3a1f04e3-345c-406b-948d-40bbb12e141e.png)
